### PR TITLE
feat: add allocator-token-exchange example

### DIFF
--- a/Third Party Notices.md
+++ b/Third Party Notices.md
@@ -22,4 +22,12 @@ Component Name: stretchr/testify
 
 License Type: "MIT"
 
-[logrus License](https://github.com/stretchr/testify/blob/master/LICENSE)
+[testify License](https://github.com/stretchr/testify/blob/master/LICENSE)
+
+--- 
+
+Component Name: golang-jwt/jwt
+
+License Type: "MIT"
+
+[golang-jwt License](https://github.com/golang-jwt/jwt/blob/main/LICENSE)

--- a/allocator-token-exchange/go.mod
+++ b/allocator-token-exchange/go.mod
@@ -1,0 +1,5 @@
+module github.com/Unity-Technologies/multiplay-examples/allocator-token-exchange
+
+go 1.18
+
+require github.com/golang-jwt/jwt/v4 v4.4.2

--- a/allocator-token-exchange/go.sum
+++ b/allocator-token-exchange/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/allocator-token-exchange/internal/token/token.go
+++ b/allocator-token-exchange/internal/token/token.go
@@ -29,9 +29,7 @@ type Token struct {
 
 // uggTokenExchange is the request body for the token exchange.
 type uggTokenExchange struct {
-	ApiKeyPublicIdentifier string   `json:"apiKeyPublicIdentifier"`
-	Secret                 string   `json:"secret"`
-	Scopes                 []string `json:"scopes"`
+	Scopes []string `json:"scopes"`
 }
 
 // uggTokenExchange is the returned body for the token exchange.
@@ -55,9 +53,7 @@ func (te *Token) RefreshToken() error {
 	}
 
 	content, err := json.Marshal(&uggTokenExchange{
-		ApiKeyPublicIdentifier: te.accessKey,
-		Secret:                 te.secretKey,
-		Scopes:                 []string{},
+		Scopes: []string{},
 	})
 	if err != nil {
 		return fmt.Errorf("%w: marshal token exchange", err)
@@ -68,6 +64,7 @@ func (te *Token) RefreshToken() error {
 	q.Add("environmentId", te.environmentID)
 	req.URL.RawQuery = q.Encode()
 	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(te.accessKey, te.secretKey)
 	resp, err := c.Do(req)
 	if err != nil {
 		return fmt.Errorf("%w: do token exchange", err)

--- a/allocator-token-exchange/internal/token/token.go
+++ b/allocator-token-exchange/internal/token/token.go
@@ -1,0 +1,125 @@
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const (
+	tokenExchangeURL = "https://services.api.unity.com/auth/v1/token-exchange"
+)
+
+// Token is a unity token which refreshes.
+type Token struct {
+	projectID     string
+	environmentID string
+	accessKey     string
+	secretKey     string
+
+	token  string
+	claims jwt.RegisteredClaims
+}
+
+// uggTokenExchange is the request body for the token exchange.
+type uggTokenExchange struct {
+	ApiKeyPublicIdentifier string   `json:"apiKeyPublicIdentifier"`
+	Secret                 string   `json:"secret"`
+	Scopes                 []string `json:"scopes"`
+}
+
+// uggTokenExchange is the returned body for the token exchange.
+type uggAuthentication struct {
+	AccessToken string `json:"accessToken"`
+}
+
+// NewToken creates a new token object which auto refreshes.
+func NewToken(projectID, environmentID, accessKey, secretKey string) Token {
+	return Token{
+		projectID:     projectID,
+		environmentID: environmentID,
+		accessKey:     accessKey,
+		secretKey:     secretKey,
+	}
+}
+
+func (te *Token) RefreshToken() error {
+	c := &http.Client{
+		Timeout: time.Minute,
+	}
+
+	content, err := json.Marshal(&uggTokenExchange{
+		ApiKeyPublicIdentifier: te.accessKey,
+		Secret:                 te.secretKey,
+		Scopes:                 []string{},
+	})
+	if err != nil {
+		return fmt.Errorf("%w: marshal token exchange", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, tokenExchangeURL, bytes.NewReader(content))
+	q := req.URL.Query()
+	q.Add("projectId", te.projectID)
+	q.Add("environmentId", te.environmentID)
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: do token exchange", err)
+	}
+	defer func() {
+		// We don't care about the body, just ensure it is drained and closed.
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("token exchange status code: %d", resp.StatusCode)
+	}
+
+	var o uggAuthentication
+	err = json.NewDecoder(resp.Body).Decode(&o)
+	if err != nil {
+		return fmt.Errorf("%w: decode token exchange", err)
+	}
+
+	token, _, err := jwt.NewParser().ParseUnverified(o.AccessToken, &jwt.RegisteredClaims{})
+	claims, ok := token.Claims.(*jwt.RegisteredClaims)
+	if !ok || claims == nil {
+		return fmt.Errorf("claims invalid")
+	}
+
+	if claims.ExpiresAt == nil || claims.ExpiresAt.Unix() < time.Now().Unix() {
+		return fmt.Errorf("received expired token")
+	}
+
+	te.claims = *claims
+	te.token = o.AccessToken
+
+	return nil
+}
+
+// BearerToken returns the bearer token
+func (te *Token) BearerToken() (string, error) {
+	if te.claims.ExpiresAt == nil || te.claims.ExpiresAt.Unix() < time.Now().Add(-time.Minute).Unix() {
+		// We have no token, or it is about to expire, so refresh it.
+		if err := te.RefreshToken(); err != nil {
+			return "", fmt.Errorf("refresh token: %w", err)
+		}
+	}
+	return te.token, nil
+}
+
+// AddRequestBearerToken adds the bearer token to a request
+func (te *Token) AddRequestBearerToken(r *http.Request) error {
+	t, err := te.BearerToken()
+	if err != nil {
+		return fmt.Errorf("get bearer token: %w", err)
+	}
+	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t))
+	return nil
+}

--- a/allocator-token-exchange/main.go
+++ b/allocator-token-exchange/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/Unity-Technologies/multiplay-examples/allocator-token-exchange/internal/token"
+)
+
+// ExampleAuthenticatedCall tries to get a non-existent allocation. Authenticating correctly, but not finding it.
+func ExampleAuthenticatedCall(token token.Token, projectID, environmentID, fleetID string) error {
+	url := fmt.Sprintf(
+		"https://services.api.unity.com/multiplay/v1/allocations/projects/%s/environments/%s/fleets/%s/allocations/00000000-0000-0000-0000-000000000000",
+		projectID,
+		environmentID,
+		fleetID,
+	)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	err = token.AddRequestBearerToken(req)
+	if err != nil {
+		return fmt.Errorf("error adding bearer token: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer func() {
+		// We don't care about the body, just ensure it is drained and closed.
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("expecteed 404 but received: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func main() {
+	var projectID, environmentId, fleetID, accessKey, secretKey string
+
+	f := flag.FlagSet{}
+	f.StringVar(&projectID, "projectID", "", "project id to use")
+	f.StringVar(&environmentId, "environmentID", "", "environment id to use")
+	f.StringVar(&fleetID, "fleetID", "", "environment id to use (optional for example call)")
+	f.StringVar(&accessKey, "accessKey", "", "access key to use")
+	f.StringVar(&secretKey, "secretKey", "", "secret key to use")
+	if err := f.Parse(os.Args[1:]); err != nil {
+		log.Fatal("error parsing flags", err.Error())
+	}
+
+	if environmentId == "" {
+		log.Fatal("environmentID is required")
+	}
+	if projectID == "" {
+		log.Fatal("projectID is required")
+	}
+	if fleetID == "" {
+		fleetID = "39b2a8c1-b1f2-4083-a3fa-06f0f45724b8"
+	}
+	if accessKey == "" {
+		log.Fatal("accessKey is required")
+	}
+	if secretKey == "" {
+		log.Fatal("secretKey is required")
+	}
+
+	te := token.NewToken(projectID, environmentId, accessKey, secretKey)
+
+	// Continuously try to get a token, and then make an authenticated call. Reuse token and refresh if needed.
+	for {
+		time.Sleep(10 * time.Second)
+		t, err := te.BearerToken()
+		if err != nil {
+			log.Println("failed to get bearer token", err)
+			continue
+		}
+		fmt.Println("Using token", t[:25], "...", t[len(t)-25:])
+
+		err = ExampleAuthenticatedCall(te, projectID, environmentId, fleetID)
+		if err != nil {
+			log.Println("failed to authenticate multiplay call", err)
+			continue
+		}
+		fmt.Println("Successfully authed call")
+
+	}
+}

--- a/allocator-token-exchange/main.go
+++ b/allocator-token-exchange/main.go
@@ -82,20 +82,23 @@ func main() {
 
 	// Continuously try to get a token, and then make an authenticated call. Reuse token and refresh if needed.
 	for {
-		time.Sleep(10 * time.Second)
+		// You Example just getting the bearer token as a string.
 		t, err := te.BearerToken()
 		if err != nil {
 			log.Println("failed to get bearer token", err)
+			time.Sleep(10 * time.Second)
 			continue
 		}
-		fmt.Println("Using token", t[:25], "...", t[len(t)-25:])
+		fmt.Println("Retrieved token", t[:25], "...", t[len(t)-25:])
 
+		// Example of populating the Authorization header on a request.
 		err = ExampleAuthenticatedCall(te, projectID, environmentId, fleetID)
 		if err != nil {
 			log.Println("failed to authenticate multiplay call", err)
+			time.Sleep(10 * time.Second)
 			continue
 		}
 		fmt.Println("Successfully authed call")
-
+		time.Sleep(10 * time.Second)
 	}
 }


### PR DESCRIPTION
This adds an example of the allocator token exchange mechanism used to authenticate for high throughput calls.