### PR TITLE
feat(simple-game-server-go): Support '-logFile' flag

### DIFF
--- a/simple-game-server-go/main_test.go
+++ b/simple-game-server-go/main_test.go
@@ -8,9 +8,10 @@ import (
 
 func Test_parseFlags(t *testing.T) {
 	t.Parallel()
-	config, log, port, queryPort, err := parseFlags([]string{
+	config, log, logFile, port, queryPort, err := parseFlags([]string{
 		"-config", "my-config.json",
 		"-log", "/tmp/",
+		"-logFile", "/tmp/Engine.log",
 		"-port", "9000",
 		"-queryport", "9001",
 	})
@@ -18,6 +19,7 @@ func Test_parseFlags(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "my-config.json", config)
 	require.Equal(t, "/tmp/", log)
+	require.Equal(t, "/tmp/Engine.log", logFile)
 	require.Equal(t, uint(9000), port)
 	require.Equal(t, uint(9001), queryPort)
 }


### PR DESCRIPTION
The `-logFile` flag (logging to a specific file) takes precedence over `-log`, which logs to a file in the specified directory.