### PR TITLE
Add `tracebackLevel` flag to change the Traceback level 

### DIFF
--- a/simple-game-server-go/main.go
+++ b/simple-game-server-go/main.go
@@ -15,7 +15,15 @@ import (
 )
 
 // parseFlags parses the supported flags and returns the values supplied to these flags.
-func parseFlags(args []string) (config string, log string, logFile string, port uint, queryPort uint, tracebackLevel string, err error) {
+func parseFlags(args []string) (
+	config string,
+	log string,
+	logFile string,
+	port uint,
+	queryPort uint,
+	tracebackLevel string,
+	err error,
+) {
 	dir, _ := os.UserHomeDir()
 	f := flag.FlagSet{}
 
@@ -24,7 +32,12 @@ func parseFlags(args []string) (config string, log string, logFile string, port 
 	f.StringVar(&logFile, "logFile", "", "path to the log file to write to")
 	f.UintVar(&port, "port", 8000, "port for the game server to bind to")
 	f.UintVar(&queryPort, "queryport", 8001, "port for the query endpoint to bind to")
-	f.StringVar(&tracebackLevel, "tracebackLevel", "", "the amount of detail printed by the runtime prints before exiting due to an unrecovered panic")
+	f.StringVar(
+		&tracebackLevel,
+		"tracebackLevel",
+		"",
+		"the amount of detail printed by the runtime prints before exiting due to an unrecovered panic",
+	)
 
 	err = f.Parse(args)
 

--- a/simple-game-server-go/main.go
+++ b/simple-game-server-go/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"syscall"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 )
 
 // parseFlags parses the supported flags and returns the values supplied to these flags.
-func parseFlags(args []string) (config string, log string, logFile string, port uint, queryPort uint, err error) {
+func parseFlags(args []string) (config string, log string, logFile string, port uint, queryPort uint, tracebackLevel string, err error) {
 	dir, _ := os.UserHomeDir()
 	f := flag.FlagSet{}
 
@@ -23,6 +24,8 @@ func parseFlags(args []string) (config string, log string, logFile string, port 
 	f.StringVar(&logFile, "logFile", "", "path to the log file to write to")
 	f.UintVar(&port, "port", 8000, "port for the game server to bind to")
 	f.UintVar(&queryPort, "queryport", 8001, "port for the query endpoint to bind to")
+	f.StringVar(&tracebackLevel, "tracebackLevel", "", "the amount of detail printed by the runtime prints before exiting due to an unrecovered panic")
+
 	err = f.Parse(args)
 
 	return
@@ -32,9 +35,14 @@ func main() {
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})
 
-	config, log, logFile, port, queryPort, err := parseFlags(os.Args[1:])
+	config, log, logFile, port, queryPort, tracebackLevel, err := parseFlags(os.Args[1:])
 	if err != nil {
 		logger.WithError(err).Fatal("error parsing flags")
+	}
+
+	if tracebackLevel != "" {
+		logger.Infof("setting traceback level to %s", tracebackLevel)
+		debug.SetTraceback(tracebackLevel)
 	}
 
 	// Let -logFile take precedence over -log

--- a/simple-game-server-go/main_test.go
+++ b/simple-game-server-go/main_test.go
@@ -8,12 +8,13 @@ import (
 
 func Test_parseFlags(t *testing.T) {
 	t.Parallel()
-	config, log, logFile, port, queryPort, err := parseFlags([]string{
+	config, log, logFile, port, queryPort, tracebackLevel, err := parseFlags([]string{
 		"-config", "my-config.json",
 		"-log", "/tmp/",
 		"-logFile", "/tmp/Engine.log",
 		"-port", "9000",
 		"-queryport", "9001",
+		"-tracebackLevel", "all",
 	})
 
 	require.NoError(t, err)
@@ -22,4 +23,5 @@ func Test_parseFlags(t *testing.T) {
 	require.Equal(t, "/tmp/Engine.log", logFile)
 	require.Equal(t, uint(9000), port)
 	require.Equal(t, uint(9001), queryPort)
+	require.Equal(t, "all", tracebackLevel)
 }


### PR DESCRIPTION
The traceback level controls the amount of output generated when a Go program fails due to an unrecovered panic or an unexpected runtime condition. It's useful when you need to test the core dumps. This PR adds `tracebackLevel` flag to change the traceback level at the runtime. Since self-serve does not support the environment variable, we need to add it as a flag.