### PR TITLE
fix(simple-game-server-go): set default maxPlayers if unset

### DIFF
--- a/.github/workflows/simple-game-server-go.yml
+++ b/.github/workflows/simple-game-server-go.yml
@@ -30,7 +30,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') == false
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.18.2
           args: build --rm-dist --snapshot
           workdir: './simple-game-server-go'
         env:
@@ -42,7 +42,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, '-simple-game-server-go') }}
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.18.2
           args: release --rm-dist
           workdir: './simple-game-server-go'
         env:

--- a/simple-game-server-go/internal/game/allocated.go
+++ b/simple-game-server-go/internal/game/allocated.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const defaultMaxPlayers = 4
+
 // allocated starts a game after the server has been allocated.
 func (g *Game) allocated(allocationID string) {
 	g.logger = g.logger.WithField("allocation_uuid", allocationID)
@@ -21,6 +23,9 @@ func (g *Game) allocated(allocationID string) {
 	c := g.Config()
 	port, _ := c.Port.Int64()
 	maxPlayers, _ := strconv.ParseInt(c.Extra["maxPlayers"], 10, 32)
+	if maxPlayers == 0 {
+		maxPlayers = defaultMaxPlayers
+	}
 
 	g.Server.SetMaxPlayers(int32(maxPlayers))
 	g.Server.SetServerName(fmt.Sprintf("simple-game-server-go - %s", c.AllocatedUUID))


### PR DESCRIPTION
Since migrating to the SDK there is no default maxPlayers value. This means the maxPlayers value is reported as 0, which means the server density analytics (based on CCU as a proportion of `maxPlayers`) is always 0 for the sample.


SGS go 0.60.0 (latest) reporting 0 maxPlayers:

```json
{"time":"2023-07-14T14:33:02.053832642Z","level":"info","caller":"monitor/servers.go:191","message":"server stats","app":"servercheck","class":"","name":"simple-game-server-go - 88ed6153-2964-4810-a871-96d9d8f148cf","map":"N/A","players":3,"maxplayers":0,"mem":"8MB","cpu":0,"pid":502511,"server_id":11342240}
```

In 0.5.1 was set to 4 by default
https://github.com/Unity-Technologies/multiplay-examples/blob/f7c9e291de298b2246e521f746ab5c42a30dbe42/simple-game-server-go/pkg/config/config.go#L67

```json
{"time":"2023-07-14T14:46:02.044423311Z","level":"info","caller":"monitor/servers.go:191","message":"server stats","app":"servercheck","class":"","name":"simple-game-server-go - d2af279b-1ee0-4c31-9737-ff5d3eb2c027","map":"Sample Map","players":1,"maxplayers":4,"mem":"4MB","cpu":0,"pid":503001,"server_id":11342243}
```

This build:
```json
{"time":"2023-07-14T15:05:02.054174775Z","level":"info","caller":"monitor/servers.go:191","message":"server stats","app":"servercheck","class":"","name":"simple-game-server-go - 9832a217-f8fd-4e9b-9edb-d078d7f773ed","map":"N/A","players":1,"maxplayers":4,"mem":"7MB","cpu":0,"pid":503406,"server_id":11342246}
```