### PR TITLE
feat(simple-game-server-go): add docker image to goreleaser

### DIFF
--- a/.github/workflows/simple-game-server-go.yml
+++ b/.github/workflows/simple-game-server-go.yml
@@ -37,6 +37,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test
         run: 'go test -timeout=5m -race -v ./...'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        if: ${{ startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, '-simple-game-server-go') }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         if: ${{ startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, '-simple-game-server-go') }}

--- a/simple-game-server-go/.goreleaser.yml
+++ b/simple-game-server-go/.goreleaser.yml
@@ -21,6 +21,12 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+dockers:
+  - image_templates:
+      - docker.io/lukepowlett051/simple-game-server-go:latest
+      - docker.io/lukepowlett051/simple-game-server-go:v{{ .Major }}
+      - docker.io/lukepowlett051/simple-game-server-go:v{{ .Major }}.{{ .Minor }}
+      - docker.io/lukepowlett051/simple-game-server-go:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/simple-game-server-go/.goreleaser.yml
+++ b/simple-game-server-go/.goreleaser.yml
@@ -23,10 +23,10 @@ archives:
         format: zip
 dockers:
   - image_templates:
-      - docker.io/lukepowlett051/simple-game-server-go:latest
-      - docker.io/lukepowlett051/simple-game-server-go:v{{ .Major }}
-      - docker.io/lukepowlett051/simple-game-server-go:v{{ .Major }}.{{ .Minor }}
-      - docker.io/lukepowlett051/simple-game-server-go:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+      - docker.io/unitymultiplay/simple-game-server-go:latest
+      - docker.io/unitymultiplay/simple-game-server-go:v{{ .Major }}
+      - docker.io/unitymultiplay/simple-game-server-go:v{{ .Major }}.{{ .Minor }}
+      - docker.io/unitymultiplay/simple-game-server-go:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/simple-game-server-go/Dockerfile
+++ b/simple-game-server-go/Dockerfile
@@ -1,0 +1,7 @@
+FROM unitymultiplay/linux-base-image:latest
+
+USER root
+COPY ./simple-game-server-go /usr/local/bin/
+USER mpukgame
+
+ENTRYPOINT ["simple-game-server-go"]


### PR DESCRIPTION
On release creation build and push a simple-game-server-go image to `docker.io/unitymultiplay/simple-game-server-go` for use with the GSH container upload build workflow.

Tested using a private docker repo `lukepowlett051` on the main branch of this fork.

**git releases**
<img width="1917" alt="Screenshot 2023-08-03 at 16 01 56" src="https://github.com/Unity-Technologies/multiplay-examples/assets/86303623/e1046343-ca63-4522-aa71-26c2efbad839">

**dockerhub images**
<img width="1920" alt="Screenshot 2023-08-03 at 16 02 19" src="https://github.com/Unity-Technologies/multiplay-examples/assets/86303623/17f1ef9f-09ca-43d8-9c04-1d0ed467edd5">

**running server using build**
<img width="1916" alt="Screenshot 2023-08-03 at 16 04 39" src="https://github.com/Unity-Technologies/multiplay-examples/assets/86303623/5eebbc0f-12c7-430d-8f84-1c0da86629d2">
